### PR TITLE
Pin mink==0.0.10 and add missing IK/data deps so GR1 + abstract replay work from a clean install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,16 @@ setup(
         "lxml",
         "hidapi",
         "tianshou==0.4.10",
+        # --- whole-body IK + data tooling needed by the GR1 / abstract paths ---
+        # mink 0.0.10 is the last release that (a) keeps the `mink.tasks.exceptions`
+        # import path used by robosuite's mink_controller and (b) requires
+        # mujoco>=3.1.6 (compatible with the pinned mujoco==3.2.6). mink 0.0.11+
+        # moved that symbol (ImportError) and 1.x requires mujoco>=3.3 (conflicts
+        # with 3.2.6), so an unpinned mink breaks `--robots GR1TwoHand`.
+        "mink==0.0.10",
+        "quadprog",          # default QP backend for mink.solve_ik
+        "robosuite_models",  # GR1 (and other) robot models
+        "huggingface_hub",   # used by scripts/download_mimicdroid_dataset.py
     ],
     eager_resources=["*"],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         # with 3.2.6), so an unpinned mink breaks `--robots GR1TwoHand`.
         "mink==0.0.10",
         "quadprog",          # default QP backend for mink.solve_ik
-        "robosuite_models",  # GR1 (and other) robot models
         "huggingface_hub",   # used by scripts/download_mimicdroid_dataset.py
     ],
     eager_resources=["*"],


### PR DESCRIPTION
### Problem

Following the README on a fresh environment, `replay_dataset.py --robots GR1TwoHand` (the GR1 half of the benchmark) fails, because two runtime dependencies are neither declared nor documented:

- `mink` (whole-body IK) and `quadprog` (mink's default QP solver — otherwise `qpsolvers.exceptions.SolverNotFound`). (`huggingface_hub`, used by `scripts/download_mimicdroid_dataset.py`, is likewise undeclared.)

Worse, with `mink` unpinned a fresh install pulls the latest release, which breaks two ways:

- `mink>=0.0.11` moved `TargetNotSet` out of `mink.tasks.exceptions`, so `robosuite/examples/third_party_controller/mink_controller.py` raises `ModuleNotFoundError: No module named 'mink.tasks.exceptions'` at import → `WHOLE_BODY_MINK_IK` is never registered → `AssertionError: Controller WHOLE_BODY_MINK_IK not found`.
- `mink>=1.0.0` additionally requires `mujoco>=3.3`, conflicting with the pinned `mujoco==3.2.6`.

### Fix

Pin `mink==0.0.10` — the last release that (a) keeps the `mink.tasks.exceptions` layout that `mink_controller` imports and (b) requires `mujoco>=3.1.6` (compatible with `mujoco==3.2.6`) — and add `quadprog` + `huggingface_hub`. This makes the controller import cleanly **without patching robosuite and without a mujoco override**.

### Verification

Fresh Python 3.10 venv, headless EGL (`MUJOCO_GL=egl`), kitchen assets + a `TaskDemos` episode downloaded per the README:

- `replay_dataset.py --robots DemoTwoHand --use_camera_obs` → `Success: True`
- `replay_dataset.py --robots GR1TwoHand --use_camera_obs` → `Success: True`

(GR1 and DemoTwoHand models ship in the `abs_robot` fork itself, so `robosuite_models` is not required for either embodiment.)

Refs #6, #7 (reproducibility / setup questions).